### PR TITLE
Fix: Allow empty result string in reviewDiff validation

### DIFF
--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -77,8 +77,8 @@ export const reviewDiff = async (
       }
       console.log('[Amp] Iterator completed');
 
-      // Check if threadId and result are defined
-      if (!threadId || !result) throw new Error('Amp review failed');
+      // Check if threadId is defined (result can be empty when AI only uses tools)
+      if (!threadId) throw new Error('No thread ID received from Amp');
 
       return { success: true, threadId, result, commentsFilePath };
   } catch (error) {


### PR DESCRIPTION
> [!IMPORTANT] 
> Solves #7 

## Problem

The `reviewDiff` function in `reviewer.ts` rejects valid review completions when the AI agent returns an empty string as the result. This occurs with large diffs (130K+ chars) where the agent uses only toolbox functions (`leave_inline_comment`, `leave_general_comment`) without additional text output.

**Error observed:**
```
[Amp] Started thread: T-06b3f3b3-a708-08371dc31a64
[Amp] Review completed successfully
Error starting thread: Error: Amp review failed
```

## Root Cause

Line 81 in `src/review/reviewer.ts`:
```typescript
if (!threadId || !result) throw new Error('Amp review failed');
```

- Empty string is falsy in JavaScript, so `!result` evaluates to `true`
- This causes the check to fail even when the review succeeded
- Comments are collected via the JSONL file, not the `result` string
- The `result` field is never used after being returned (verified in `process-review.ts`)

## Solution

Changed the validation to only check for `threadId`:
```typescript
if (!threadId) throw new Error('No thread ID received from Amp');
```

This allows empty result strings (which should be  valid when AI uses only tools to write comments) while still catching legitimate errors (no thread created).

## Testing

-  TypeScript type-check passes
-  Build succeeds
-  Verified `result` field is never accessed in `process-review.ts`
-  Reproduced the bug locally with tool-only AI responses
-  Confirmed fix resolves the issue when triggered on the local docker

## Impact

- **Safe:** `result` field is never used after this, so removing the check doesn't break anything
- **Backward compatible:** Still returns `result` in response object